### PR TITLE
Fix data labels in ggplotly-vs-plotly.Rmd

### DIFF
--- a/ggplotly-vs-plotly.Rmd
+++ b/ggplotly-vs-plotly.Rmd
@@ -252,7 +252,7 @@ p <- ggplot(diamonds, aes(cut, fill = clarity)) +
 ggplotly(p, originalData = FALSE) %>%
   mutate(ydiff = ymax - ymin) %>% 
   add_text(
-    x = ~x, y = ~1 - (ymin + ymax) / 2,
+    x = ~x, y = ~(ymin + ymax) / 2,
     text = ~ifelse(ydiff > 0.02, round(ydiff, 2), ""),
     showlegend = FALSE, hoverinfo = "none",
     color = I("black"), size = I(9)


### PR DESCRIPTION
The data labels are not aligning to their respective segments. My guess is that this broke with ggplot2 2.2.0 which reversed the order stacking from the group order.

I've tested the change to ensure the results are correct with the most up-to-date version of plotly and ggplot2, but I am leaving any site-building changes to you as I do not know how that works and assume you have your way of doing that.