### PR TITLE
zoom instead of truncate

### DIFF
--- a/arranging.Rmd
+++ b/arranging.Rmd
@@ -188,7 +188,8 @@ The same problems and principles that inspired scagnostics has inspired work on 
 library(trelliscopejs)
 
 qplot(cty, hwy, data = mpg) +
-  xlim(7, 37) + ylim(9, 47) + theme_bw() +
+  coord_cartesian(xlim=c(7, 37), ylim=c(9, 47)) + 
+  theme_bw() +
   facet_trelliscope(
     ~ manufacturer + class, nrow = 2, ncol = 4, 
     as_plotly = TRUE, plotly_args = list(dynamicTicks = T)


### PR DESCRIPTION
in this specific scenario, they're the same, but I think using `coord_cartesian()` (which zooms) instead of `xlim()` (which truncates) is a better template for readers to copy & paste into their own R files.  Some of them may not be aware of the difference.

1. http://rstudio-pubs-static.s3.amazonaws.com/209392_437ec4da7fa2432d831320f3591e7491.html
1. https://www.r-bloggers.com/ggplot2-axis-limit-gotchas/
1. https://stackoverflow.com/questions/25685185/limit-ggplot2-axes-without-removing-data-outside-limits-zoom