### PR TITLE
Remove deprecated scales function `number_si()`

### DIFF
--- a/topics.Rmd
+++ b/topics.Rmd
@@ -204,7 +204,7 @@ library(scales)
 p <- ggplot(txhousing, aes(date, median)) + 
   geom_line(aes(
     group = city, 
-    text = paste("median:", number_si(median))
+    text = paste("median:", label_number(scale_cut = cut_short_scale())(median)
   ))
 ggplotly(p, tooltip = c("text", "x", "city"))
 ```
@@ -229,10 +229,10 @@ length(w$x$data)
 
 # use the `y` attribute of the smooth line 
 # to generate a custom string (to appear in tooltip)
-text_y <- number_si(
-  w$x$data[[2]]$y, 
+text_y <- label_number(
+  scale_cut = cut_short_scale(), 
   prefix = "Typical median house price: $"
-)
+)(w$x$data[[2]]$y)
 
 # suppress the tooltip on the raw time series 
 # and supply custom text to the smooth line


### PR DESCRIPTION
fix #84 

`label_number_si()` is defunct now in favour of `label_number(scale_cut = )`

https://www.tidyverse.org/blog/2022/04/scales-1-2-0/#numbers

This code would currently error due to a bug in scales https://github.com/r-lib/scales/issues/413. But would work for scales 1.2.0 and 1.21, and will work for scales (>= 1.3.1)